### PR TITLE
build with node-gyp (fixes issues on OS X with 0.8.4)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,24 @@
+{
+  "targets": [
+    {
+      "target_name": "lzf",
+      "sources": [
+        "src/lzf.cc",
+        "src/lzf/lzf_c.cc",
+        "src/lzf/lzf_d.cc",
+        "src/lzf/lzf.h",
+        "src/lzf/lzfP.h"
+      ],
+      'conditions': [
+        [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
+          'cflags': ['-O2']
+        }],
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'OTHER_CFLAGS': ['-O2']
+          }
+        }]
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
on OS.X with 0.8.4 node-waf fails to build node-lzf correctly.
`npm install` doesn't report any error but `require` will not work

```
> require('lzf')
Error: dlopen(/Users/carlos/t49/node_modules/lzf/build/Release/lzf.node, 1): no suitable image found.  Did find:
    /Users/carlos/t49/node_modules/lzf/build/Release/lzf.node: mach-o, but wrong architecture
    at Object.Module._extensions..node (module.js:485:11)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/Users/carlos/t49/node_modules/lzf/index.js:4:22)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
```

`node-gyp` (with this `binding.gyp`) works for me
